### PR TITLE
feat: add MiniMax-M2.7 AI content generator

### DIFF
--- a/scripts/generate-content.py
+++ b/scripts/generate-content.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""
+html-ppt :: generate-content.py — AI-powered slide content generator
+
+Uses MiniMax-M2.7 (OpenAI-compatible API) to generate a structured slide
+outline from a topic, which you can then turn into a deck with new-deck.sh.
+
+Usage:
+  python scripts/generate-content.py "LangChain 入门" --slides 8 --lang zh
+  python scripts/generate-content.py "AI Safety 101" --slides 6 --lang en --output my-outline.json
+
+Environment:
+  MINIMAX_API_KEY   required — your MiniMax API key (https://platform.minimax.io)
+
+Output (JSON):
+  {
+    "title": "Deck title",
+    "theme": "suggested theme name",
+    "slides": [
+      {
+        "layout": "layout type (e.g. cover, bullets, two-column, kpi-grid)",
+        "title": "slide title",
+        "content": "main content / bullet points",
+        "notes": "speaker notes (100–200 words)"
+      },
+      ...
+    ]
+  }
+
+Pipe into jq or drop the JSON into your deck for a quick starting point.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+MINIMAX_BASE_URL = "https://api.minimax.io/v1"
+DEFAULT_MODEL = "MiniMax-M2.7"
+
+# Available layouts in html-ppt (for the model to pick from)
+LAYOUTS = [
+    "cover", "toc", "section-divider", "bullets", "two-column", "three-column",
+    "big-quote", "stat-highlight", "kpi-grid", "table", "code", "diff",
+    "terminal", "flow-diagram", "timeline", "roadmap", "mindmap", "comparison",
+    "pros-cons", "todo-checklist", "gantt", "image-hero", "image-grid",
+    "chart-bar", "chart-line", "chart-pie", "chart-radar", "arch-diagram",
+    "process-steps", "cta", "thanks",
+]
+
+# Available themes in html-ppt (for the model to pick from)
+THEMES = [
+    "minimal-white", "editorial-serif", "soft-pastel", "sharp-mono",
+    "arctic-cool", "sunset-warm", "catppuccin-latte", "catppuccin-mocha",
+    "dracula", "tokyo-night", "nord", "solarized-light", "gruvbox-dark",
+    "rose-pine", "neo-brutalism", "glassmorphism", "bauhaus", "swiss-grid",
+    "terminal-green", "xiaohongshu-white", "rainbow-gradient", "aurora",
+    "blueprint", "memphis-pop", "cyberpunk-neon", "y2k-chrome", "retro-tv",
+    "japanese-minimal", "vaporwave", "midcentury", "corporate-clean",
+    "academic-paper", "news-broadcast", "pitch-deck-vc", "magazine-bold",
+    "engineering-whiteprint",
+]
+
+
+def build_system_prompt(lang: str) -> str:
+    lang_label = "Chinese (Simplified)" if lang == "zh" else "English"
+    return (
+        f"You are an expert presentation designer specialising in clear, engaging decks. "
+        f"Generate structured slide content in {lang_label}. "
+        f"Output valid JSON only — no markdown fences, no explanation. "
+        f"Available layouts: {', '.join(LAYOUTS)}. "
+        f"Available themes: {', '.join(THEMES)}."
+    )
+
+
+def build_user_prompt(topic: str, num_slides: int) -> str:
+    return f"""Create a {num_slides}-slide presentation for: "{topic}"
+
+Return this exact JSON structure:
+{{
+  "title": "<deck title>",
+  "theme": "<one theme from the available list that fits the topic>",
+  "slides": [
+    {{
+      "layout": "<one layout from the available list>",
+      "title": "<slide title>",
+      "content": "<main content — bullet points separated by \\n, or a short paragraph>",
+      "notes": "<speaker notes, 100–200 words, conversational tone>"
+    }}
+  ]
+}}
+
+Rules:
+- First slide must use layout "cover".
+- Last slide must use layout "thanks".
+- Vary layouts — avoid repeating the same layout more than twice in a row.
+- notes must be 100–200 words, written as if spoken aloud (not read).
+- Return only valid JSON, nothing else."""
+
+
+def generate_outline(
+    topic: str,
+    num_slides: int = 8,
+    lang: str = "zh",
+    model: str = DEFAULT_MODEL,
+) -> dict:
+    """Call MiniMax-M2.7 and return a parsed slide outline dict."""
+    try:
+        from openai import OpenAI  # type: ignore
+    except ImportError:
+        sys.exit(
+            "error: openai package not found.\n"
+            "Install it with:  pip install openai"
+        )
+
+    api_key = os.environ.get("MINIMAX_API_KEY")
+    if not api_key:
+        sys.exit(
+            "error: MINIMAX_API_KEY environment variable is not set.\n"
+            "Get a key at https://platform.minimax.io and export it:\n"
+            "  export MINIMAX_API_KEY=<your-key>"
+        )
+
+    client = OpenAI(api_key=api_key, base_url=MINIMAX_BASE_URL)
+
+    response = client.chat.completions.create(
+        model=model,
+        messages=[
+            {"role": "system", "content": build_system_prompt(lang)},
+            {"role": "user", "content": build_user_prompt(topic, num_slides)},
+        ],
+        temperature=1.0,  # MiniMax requires temperature in (0.0, 1.0]
+        max_tokens=4096,
+    )
+
+    raw = response.choices[0].message.content.strip()
+
+    # Strip extended-thinking blocks (<think>...</think>) that some models emit
+    import re
+    raw = re.sub(r"<think>.*?</think>", "", raw, flags=re.DOTALL).strip()
+
+    # Strip accidental markdown code fences
+    if raw.startswith("```"):
+        lines = raw.splitlines()
+        raw = "\n".join(lines[1:-1] if lines[-1].strip() == "```" else lines[1:])
+
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as exc:
+        sys.exit(f"error: model returned invalid JSON: {exc}\nRaw response:\n{raw}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate slide outlines with MiniMax-M2.7",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument("topic", help="Presentation topic or title")
+    parser.add_argument(
+        "--slides", type=int, default=8, metavar="N",
+        help="Number of slides to generate (default: 8)",
+    )
+    parser.add_argument(
+        "--lang", choices=["zh", "en"], default="zh",
+        help="Content language: zh (Chinese) or en (English) (default: zh)",
+    )
+    parser.add_argument(
+        "--output", default="outline.json", metavar="FILE",
+        help="Output JSON file path (default: outline.json)",
+    )
+    parser.add_argument(
+        "--model", default=DEFAULT_MODEL,
+        help=f"MiniMax model to use (default: {DEFAULT_MODEL})",
+    )
+    parser.add_argument(
+        "--print", dest="print_json", action="store_true",
+        help="Also print the JSON to stdout",
+    )
+    args = parser.parse_args()
+
+    print(f"Generating {args.slides}-slide outline …")
+    print(f"  Topic : {args.topic!r}")
+    print(f"  Model : {args.model}")
+    print(f"  Lang  : {args.lang}")
+
+    outline = generate_outline(
+        topic=args.topic,
+        num_slides=args.slides,
+        lang=args.lang,
+        model=args.model,
+    )
+
+    with open(args.output, "w", encoding="utf-8") as fh:
+        json.dump(outline, fh, ensure_ascii=False, indent=2)
+        fh.write("\n")
+
+    print(f"\n✔ Saved to {args.output}")
+    print(f"  Title  : {outline.get('title', '(no title)')}")
+    print(f"  Theme  : {outline.get('theme', '(no theme)')}")
+    print(f"  Slides : {len(outline.get('slides', []))}")
+
+    if args.print_json:
+        print("\n" + json.dumps(outline, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_generate_content.py
+++ b/scripts/test_generate_content.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""
+Unit tests for scripts/generate-content.py
+
+Run:
+  python -m pytest scripts/test_generate_content.py -v
+  # or:
+  python scripts/test_generate_content.py
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+# Allow importing the hyphen-named module via importlib
+import importlib.util
+
+_scripts_dir = Path(__file__).parent
+_spec = importlib.util.spec_from_file_location(
+    "generate_content",
+    _scripts_dir / "generate-content.py",
+)
+gc = importlib.util.module_from_spec(_spec)  # type: ignore[arg-type]
+sys.modules["generate_content"] = gc
+_spec.loader.exec_module(gc)  # type: ignore[union-attr]
+
+
+# ─── helpers ──────────────────────────────────────────────────────────────────
+
+def _make_fake_response(content: str) -> MagicMock:
+    """Return a mock that looks like an OpenAI ChatCompletion response."""
+    msg = MagicMock()
+    msg.content = content
+    choice = MagicMock()
+    choice.message = msg
+    resp = MagicMock()
+    resp.choices = [choice]
+    return resp
+
+
+VALID_OUTLINE = {
+    "title": "Test Deck",
+    "theme": "tokyo-night",
+    "slides": [
+        {
+            "layout": "cover",
+            "title": "Intro",
+            "content": "• Point A\n• Point B",
+            "notes": "Welcome everyone. " * 15,  # ~200 words-ish
+        },
+        {
+            "layout": "bullets",
+            "title": "Overview",
+            "content": "• Bullet 1\n• Bullet 2",
+            "notes": "Let me walk you through. " * 12,
+        },
+        {
+            "layout": "thanks",
+            "title": "Thank you",
+            "content": "Questions?",
+            "notes": "Thank you for listening. " * 10,
+        },
+    ],
+}
+
+
+# ─── prompt-builder tests ──────────────────────────────────────────────────────
+
+class TestBuildSystemPrompt(unittest.TestCase):
+    def test_contains_language_zh(self):
+        prompt = gc.build_system_prompt("zh")
+        self.assertIn("Chinese", prompt)
+
+    def test_contains_language_en(self):
+        prompt = gc.build_system_prompt("en")
+        self.assertIn("English", prompt)
+
+    def test_lists_layouts(self):
+        prompt = gc.build_system_prompt("zh")
+        self.assertIn("cover", prompt)
+        self.assertIn("thanks", prompt)
+
+    def test_lists_themes(self):
+        prompt = gc.build_system_prompt("en")
+        self.assertIn("tokyo-night", prompt)
+        self.assertIn("dracula", prompt)
+
+
+class TestBuildUserPrompt(unittest.TestCase):
+    def test_includes_topic(self):
+        prompt = gc.build_user_prompt("AI Safety 101", 6)
+        self.assertIn("AI Safety 101", prompt)
+
+    def test_includes_slide_count(self):
+        prompt = gc.build_user_prompt("Topic", 10)
+        self.assertIn("10", prompt)
+
+    def test_cover_and_thanks_rules(self):
+        prompt = gc.build_user_prompt("Topic", 8)
+        self.assertIn("cover", prompt.lower())
+        self.assertIn("thanks", prompt.lower())
+
+
+# ─── generate_outline tests ───────────────────────────────────────────────────
+
+class TestGenerateOutline(unittest.TestCase):
+    def _run_with_mock(self, response_content: str, env: dict | None = None):
+        """Call generate_outline with a mocked OpenAI client."""
+        fake_env = {"MINIMAX_API_KEY": "test-key", **(env or {})}
+        fake_resp = _make_fake_response(response_content)
+
+        # Inject a fake openai module so we don't need it installed
+        fake_openai = types.ModuleType("openai")
+        mock_client_instance = MagicMock()
+        mock_client_instance.chat.completions.create.return_value = fake_resp
+        fake_openai.OpenAI = MagicMock(return_value=mock_client_instance)
+
+        with patch.dict("sys.modules", {"openai": fake_openai}), \
+             patch.dict("os.environ", fake_env, clear=False):
+            return gc.generate_outline("Test topic", num_slides=3)
+
+    def test_returns_dict_from_valid_json(self):
+        result = self._run_with_mock(json.dumps(VALID_OUTLINE))
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result["title"], "Test Deck")
+
+    def test_strips_markdown_fences(self):
+        wrapped = f"```json\n{json.dumps(VALID_OUTLINE)}\n```"
+        result = self._run_with_mock(wrapped)
+        self.assertEqual(result["theme"], "tokyo-night")
+
+    def test_strips_plain_code_fences(self):
+        wrapped = f"```\n{json.dumps(VALID_OUTLINE)}\n```"
+        result = self._run_with_mock(wrapped)
+        self.assertIn("slides", result)
+
+    def test_strips_thinking_blocks(self):
+        """Model may emit <think>...</think> before the JSON (extended thinking)."""
+        with_think = f"<think>I need to create slides.\nLet me think...</think>\n{json.dumps(VALID_OUTLINE)}"
+        result = self._run_with_mock(with_think)
+        self.assertEqual(result["title"], "Test Deck")
+
+    def test_passes_temperature_1(self):
+        """MiniMax requires temperature in (0.0, 1.0] — must not be 0."""
+        fake_env = {"MINIMAX_API_KEY": "test-key"}
+        fake_resp = _make_fake_response(json.dumps(VALID_OUTLINE))
+
+        fake_openai = types.ModuleType("openai")
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = fake_resp
+        fake_openai.OpenAI = MagicMock(return_value=mock_client)
+
+        with patch.dict("sys.modules", {"openai": fake_openai}), \
+             patch.dict("os.environ", fake_env, clear=False):
+            gc.generate_outline("Topic", num_slides=3)
+
+        call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+        temperature = call_kwargs.get("temperature", call_kwargs.get("temperature"))
+        self.assertGreater(temperature, 0.0, "temperature must be > 0.0 for MiniMax")
+        self.assertLessEqual(temperature, 1.0, "temperature must be <= 1.0 for MiniMax")
+
+    def test_uses_minimax_base_url(self):
+        fake_env = {"MINIMAX_API_KEY": "test-key"}
+        fake_resp = _make_fake_response(json.dumps(VALID_OUTLINE))
+
+        fake_openai = types.ModuleType("openai")
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = fake_resp
+        captured_kwargs: dict = {}
+
+        def capture(**kw):
+            captured_kwargs.update(kw)
+            return mock_client
+
+        fake_openai.OpenAI = capture
+
+        with patch.dict("sys.modules", {"openai": fake_openai}), \
+             patch.dict("os.environ", fake_env, clear=False):
+            gc.generate_outline("Topic", num_slides=3)
+
+        base_url = captured_kwargs.get("base_url", "")
+        self.assertIn("api.minimax.io", base_url)
+
+    def test_default_model_is_minimax_m27(self):
+        self.assertEqual(gc.DEFAULT_MODEL, "MiniMax-M2.7")
+
+    def test_missing_api_key_exits(self):
+        fake_openai = types.ModuleType("openai")
+        fake_openai.OpenAI = MagicMock()
+
+        with patch.dict("sys.modules", {"openai": fake_openai}), \
+             patch.dict("os.environ", {}, clear=True), \
+             self.assertRaises(SystemExit):
+            gc.generate_outline("Topic")
+
+
+# ─── constants sanity-checks ──────────────────────────────────────────────────
+
+class TestConstants(unittest.TestCase):
+    def test_layouts_not_empty(self):
+        self.assertGreater(len(gc.LAYOUTS), 0)
+
+    def test_cover_in_layouts(self):
+        self.assertIn("cover", gc.LAYOUTS)
+
+    def test_thanks_in_layouts(self):
+        self.assertIn("thanks", gc.LAYOUTS)
+
+    def test_themes_not_empty(self):
+        self.assertGreater(len(gc.THEMES), 0)
+
+    def test_tokyo_night_in_themes(self):
+        self.assertIn("tokyo-night", gc.THEMES)
+
+    def test_base_url_is_international(self):
+        """Must use international domain, not api.minimax.chat."""
+        self.assertIn("api.minimax.io", gc.MINIMAX_BASE_URL)
+        self.assertNotIn("api.minimax.chat", gc.MINIMAX_BASE_URL)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What this PR adds

A new utility script `scripts/generate-content.py` that uses **MiniMax-M2.7** (via the OpenAI-compatible API at `api.minimax.io`) to generate structured JSON slide outlines from a topic description.

### Why this is useful

html-ppt already gives agents an excellent template system. This script adds the AI-assisted first step: turning a topic or brief into a structured JSON outline that lists the recommended theme, layout-per-slide, content, and speaker notes — all ready to be scaffolded with `new-deck.sh`.

### Usage

```bash
export MINIMAX_API_KEY=<your-key>

# Generate an 8-slide Chinese deck
python scripts/generate-content.py "LangChain 入门" --slides 8 --lang zh

# Generate a 6-slide English deck with a custom model and print output
python scripts/generate-content.py "AI Safety 101" --slides 6 --lang en \
  --model MiniMax-M2.7-highspeed --print
```

### Output (JSON)

```json
{
  "title": "LangChain 入门",
  "theme": "tokyo-night",
  "slides": [
    { "layout": "cover",    "title": "...", "content": "...", "notes": "..." },
    { "layout": "bullets",  "title": "...", "content": "...", "notes": "..." },
    ...
    { "layout": "thanks",   "title": "...", "content": "...", "notes": "..." }
  ]
}
```

### Files changed

| File | Purpose |
|------|---------|
| `scripts/generate-content.py` | Main script — MiniMax-M2.7 content generator |
| `scripts/test_generate_content.py` | 21 unit tests (no API key needed) |

### Implementation notes

- Uses MiniMax-M2.7 (default) or MiniMax-M2.7-highspeed via `--model`
- Base URL: `https://api.minimax.io/v1` (international endpoint)
- Temperature fixed at `1.0` (MiniMax requires `> 0.0`)
- Handles extended-thinking `<think>…</think>` blocks and markdown code fences
- Zero new dependencies if `openai` SDK is already installed; exits with a clear message if not

### API reference

- Chat (OpenAI Compatible): https://platform.minimax.io/docs/api-reference/text-openai-api